### PR TITLE
Removing references of `cred.yml` from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Install the collection ([Galaxy link](https://galaxy.ansible.com/cisco/meraki))
 ansible-galaxy collection install cisco.meraki
 ```
 ## Use
-First, define a `credentials.yml` ([example](https://github.com/cisco-en-programmability/meraki-ansible/blob/main/playbooks/credentials.template)) file where you specify your Meraki credentials as Ansible variables:
+First, your Meraki API key needs to be available for the playbook to use. You can leverage environment variables `export MERAKI_DASHBOARD_API_KEY=093b24e85df15a3e66f1fc359f4c48493eaa1b73`, or create a `credentials.yml` ([example](https://github.com/cisco-en-programmability/meraki-ansible/blob/main/playbooks/credentials.template)) file.
+**Note:** storing your API key in an unencrypted text file is not recommended for security reasons.
 ```
 ---
 meraki_api_key: "ABC"
@@ -93,13 +94,11 @@ Then, create a playbook `myplaybook.yml` ([example](https://github.com/cisco-en-
 ```
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Get all administered _identities _me
       cisco.meraki.administered_identities_me_info:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
       register: result
 
 ```

--- a/playbooks/administered_identities_me_info.yml
+++ b/playbooks/administered_identities_me_info.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Get all administered _identities _me
       cisco.meraki.administered_identities_me_info:
-        meraki_api_key: "{{meraki_api_key}}"
+        # meraki_api_key: "{{meraki_api_key}}"
         # meraki_username: "{{meraki_username}}"
         # meraki_password: "{{meraki_password}}"
         # meraki_verify: "{{meraki_verify}}"
@@ -22,4 +20,9 @@
         # organizationId: "575334852396583071"
         # api:
         #   enabled: false
+      meraki_suppress_logging: true
       register: result
+
+    - name: Show result
+      ansible.builtin.debug:
+        msg: "{{ result }}"

--- a/playbooks/device_blink_leds.yml
+++ b/playbooks/device_blink_leds.yml
@@ -1,12 +1,9 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.devices_blink_leds:
-        meraki_api_key: "{{meraki_api_key}}"
         # meraki_base_url: "{{meraki_base_url}}"
         # meraki_single_request_timeout: "{{meraki_single_request_timeout}}"
         # meraki_certificate_path: "{{meraki_certificate_path}}"
@@ -27,7 +24,8 @@
         # meraki_caller: "{{meraki_caller}}"
         # meraki_use_iterator_for_get_pages: "{{meraki_use_iterator_for_get_pages}}"
         # meraki_inherit_logging_config: "{{meraki_inherit_logging_config}}"
+        meraki_suppress_logging: true
         duration: 20
         duty: 50
         period: 160
-        serial: QBSB-AX45-LY9A
+        serial: "QBSB-AX45-LY9A"

--- a/playbooks/devices.yml
+++ b/playbooks/devices.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Update by id
       cisco.meraki.devices:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         lat: "37.4180951010364"
         lng: "-122.098531723021"

--- a/playbooks/devices_info.yml
+++ b/playbooks/devices_info.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Get Device
       cisco.meraki.devices_info:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         organizationId: "828099381482762270"
         # serial: QBSD-36C3-473D
         # tags: ["recently-added"]

--- a/playbooks/devices_live_tools_ping.yml
+++ b/playbooks/devices_live_tools_ping.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.devices_live_tools_ping:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         # meraki_base_url: "{{meraki_base_url}}"
         # meraki_single_request_timeout: "{{meraki_single_request_timeout}}"
         # meraki_certificate_path: "{{meraki_certificate_path}}"

--- a/playbooks/devices_switch_routing_interfaces.yml
+++ b/playbooks/devices_switch_routing_interfaces.yml
@@ -1,11 +1,9 @@
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
   - name: Create
     cisco.meraki.devices_switch_routing_interfaces:
-      meraki_api_key: "{{meraki_api_key}}"
+      meraki_suppress_logging: true
       state: present
       defaultGateway: 192.168.1.1
       interfaceIp: 192.168.1.2

--- a/playbooks/networks.yml
+++ b/playbooks/networks.yml
@@ -1,7 +1,5 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     # - name: Get all networks
@@ -17,7 +15,7 @@
     #   register: result
     - name: Create
       cisco.meraki.networks:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         # copyFromNetworkId: N_24329156
         name: Site 1

--- a/playbooks/networks_appliance_vlans.yml
+++ b/playbooks/networks_appliance_vlans.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.networks_appliance_vlans:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         applianceIp: 192.168.1.2
         cidr: 192.168.1.0/24

--- a/playbooks/networks_wireless_ssids_identityPsks.yml
+++ b/playbooks/networks_wireless_ssids_identityPsks.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.networks_wireless_ssids_identity_psks:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         expiresAt: '2018-02-11T00:00:00.090210Z'
         groupPolicyId: '101'

--- a/playbooks/organization.yml
+++ b/playbooks/organization.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.organizations:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         # meraki_username: "{{meraki_username}}"
         # meraki_password: "{{meraki_password}}"
         # meraki_verify: "{{meraki_verify}}"

--- a/playbooks/organization_info.yml
+++ b/playbooks/organization_info.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Get all Organizations
       cisco.meraki.organizations_info:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         # meraki_username: "{{meraki_username}}"
         # meraki_password: "{{meraki_password}}"
         # meraki_verify: "{{meraki_verify}}"

--- a/playbooks/organizations_adaptivePolicy_acls.yml
+++ b/playbooks/organizations_adaptivePolicy_acls.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.organizations_adaptive_policy_acls:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         description: Blocks sensitive web traffic 2
         ipVersion: ipv6

--- a/playbooks/organizations_adaptive_policy_groups.yml
+++ b/playbooks/organizations_adaptive_policy_groups.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.organizations_adaptive_policy_groups:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         # description: Group of XYZ Corp Employees
         # isDefaultGroup: false

--- a/playbooks/organizations_admin.yml
+++ b/playbooks/organizations_admin.yml
@@ -1,15 +1,14 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.organizations_admins:
-        meraki_api_key: "{{meraki_api_key}}"
-        state: present
+        meraki_suppress_logging: true
+        meraki_caller: "test 123"
+        state: absent
         name: DevNet Admin 3455
-        email: devnetmerakiadmin23@cisco.com
+        email: devnetmerakiadmin23@yopmail.com
         authenticationMethod: Email
         orgAccess: full
         networks: []

--- a/playbooks/organizations_admin_info.yml
+++ b/playbooks/organizations_admin_info.yml
@@ -1,11 +1,13 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Get all Organizations Admins
       cisco.meraki.organizations_admins_info:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         organizationId: "828099381482762270"
       register: result
+
+    - name: Show result
+      ansible.builtin.debug:
+        msg: "{{ result }}"

--- a/playbooks/organizations_camera_custom_analytics_artifacts.yml
+++ b/playbooks/organizations_camera_custom_analytics_artifacts.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.organizations_camera_custom_analytics_artifacts:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         name: Test Ansible 2
         organizationId: "828099381482762270"

--- a/playbooks/organizations_clients_search_info.yml
+++ b/playbooks/organizations_clients_search_info.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Get all organizations _clients _search
       cisco.meraki.organizations_clients_search_info:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         mac: "4c:c8:a1:01:01:c2"
         perPage: 3
         total_pages: -1

--- a/playbooks/organizations_config_templates.yml
+++ b/playbooks/organizations_config_templates.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.organizations_config_templates:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         name: "My config template"
         organizationId: "828099381482762270"
@@ -14,7 +12,7 @@
 
     # - name: Update by id
     #   cisco.meraki.organizations_config_templates:
-    #     meraki_api_key: "{{meraki_api_key}}"
+    #     meraki_suppress_logging: true
     #     state: present
     #     configTemplateId: string
     #     name: My config template
@@ -23,7 +21,7 @@
 
     # - name: Delete by id
     #   cisco.meraki.organizations_config_templates:
-    #     meraki_api_key: "{{meraki_api_key}}"
+    #     meraki_suppress_logging: true
     #     meraki_caller: "{{meraki_caller}}"
     #     meraki_use_iterator_for_get_pages: "{{meraki_use_iterator_for_get_pages}}"
     #     meraki_inherit_logging_config: "{{meraki_inherit_logging_config}}"

--- a/playbooks/organizations_config_templates_info.yml
+++ b/playbooks/organizations_config_templates_info.yml
@@ -1,11 +1,9 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Get all organizations _configtemplates
       cisco.meraki.organizations_config_templates_info:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         organizationId: "828099381482762270"
       register: result

--- a/playbooks/organizations_devices_info.yml
+++ b/playbooks/organizations_devices_info.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Get all organizations _devices
       cisco.meraki.organizations_devices_info:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         perPage: 3
         total_pages: -1
         # startingAfter: string

--- a/playbooks/organizations_saml_idps.yml
+++ b/playbooks/organizations_saml_idps.yml
@@ -1,12 +1,10 @@
 ---
 - hosts: meraki_servers
-  vars_files:
-    - credentials.yml
   gather_facts: false
   tasks:
     - name: Create
       cisco.meraki.organizations_saml_idps:
-        meraki_api_key: "{{meraki_api_key}}"
+        meraki_suppress_logging: true
         state: present
         organizationId: "828099381482762270"
         sloLogoutUrl: https://somewhere.com

--- a/playbooks/wifi_deploy_one.yml
+++ b/playbooks/wifi_deploy_one.yml
@@ -1,0 +1,18 @@
+---
+
+- hosts: meraki_servers
+  vars:
+    org_id: "828099381482762270"
+    corp_name: "ACME"
+    network_id: "L_828099381482770865"
+  gather_facts: false
+  tasks:
+
+    - name: Create corporate SSID
+      cisco.meraki.networks_wireless_ssids:
+        meraki_suppress_logging: true
+        state: present
+        enabled: true
+        name: "{{corp_name}}"
+        networkId: "{{ network_id }}"
+        number: "1"


### PR DESCRIPTION
I'd rather have the documentation demonstrate the usage of environment variables. If someone wants to store an API key in a text file - that's their (poor) choice.